### PR TITLE
Optimize SYCL URL to avoid 301 Moved Permanently on directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ The SYCL-Registry repository contains the SYCL C++ programming model for
 OpenCL, including specifications.
 
 It is also used as a backing store for the web view of the registry at
-https://www.khronos.org/registry/sycl ; commits to the master branch of
+https://www.khronos.org/registry/SYCL/ ; commits to the master branch of
 this repository will be reflected there.
 
 In the past, the SYCL registry was maintained in a public Subversion
 repository. The history in that repository has not been imported to github,
 but it is still available at
-https://cvs.khronos.org/svn/repos/registry/trunk/public/sycl .
+https://cvs.khronos.org/svn/repos/registry/trunk/public/sycl/ .
 
 Interesting files in this repository include:
 


### PR DESCRIPTION
As suggested by James Riordon, avoid an intermediate redirection such
as

wget --verbose  https://www.khronos.org/registry/SYCL
--2020-04-28 06:29:00--  https://www.khronos.org/registry/SYCL
Resolving www.khronos.org (www.khronos.org)... 104.236.24.254
Connecting to www.khronos.org (www.khronos.org)|104.236.24.254|:443... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://www.khronos.org/registry/SYCL/ [following]
--2020-04-28 06:29:00--  https://www.khronos.org/registry/SYCL/
Reusing existing connection to www.khronos.org:443.
HTTP request sent, awaiting response... 200 OK

by adding a `/` at the end of the URL when possible.