### PR TITLE
Actually the official name is Reference Guide

### DIFF
--- a/index.php
+++ b/index.php
@@ -16,13 +16,13 @@ include_once("../../assets/static_pages/khr_page_top.php");
      (April 27, 2020)
      <ul>
      <li> <a href="https://www.khronos.org/files/sycl/sycl-121-reference-card.pdf">
-      SYCL 1.2.1 Reference Card</a> </li>
+      SYCL 1.2.1 Reference Guide</a> </li>
      </ul> </li>
 <li> <a href="specs/sycl-1.2.pdf"> SYCL 1.2 Specification (obsolete)</a> (May 8,
      2015)
      <ul>
      <li> <a href="https://www.khronos.org/files/sycl/sycl-12-reference-card.pdf">
-      SYCL 1.2 Reference Card</a> </li>
+      SYCL 1.2 Reference Guide</a> </li>
      </ul> </li>
 <li> A provisional SYCL 2.2 specification was published in February 2016.  That
      specification was an incomplete work in progress, and should be considered


### PR DESCRIPTION
... instead of Reference Card.